### PR TITLE
Improve failure reporting of update checks

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -8,6 +8,7 @@
     $plugin_tx['hi_updatecheck']['message_searching']="Suche nach Updates für";    
     $plugin_tx['hi_updatecheck']['message_download']="Zur Downloadseite »";
     $plugin_tx['hi_updatecheck']['message_fail']="Update-Prüfung für %s fehlgeschlagen!";
+    $plugin_tx['hi_updatecheck']['message_fail_reason']="Grund: %s.";
     $plugin_tx['hi_updatecheck']['message_up-to-date']="ist aktuell.";
     $plugin_tx['hi_updatecheck']['message_update-available']="Für %s ist die neue Version %s verfügbar!";
     $plugin_tx['hi_updatecheck']['message_update-critical']="Dies ist ein kritisches Update! Bitte aktualisieren Sie Ihr System zeitnah!";

--- a/languages/default.php
+++ b/languages/default.php
@@ -8,6 +8,7 @@
 	$plugin_tx['hi_updatecheck']['message_searching']="Searching updates for";
 	$plugin_tx['hi_updatecheck']['message_download']="Visit downloadpage »";
 	$plugin_tx['hi_updatecheck']['message_fail']="Updatecheck for %s failed!";
+	$plugin_tx['hi_updatecheck']['message_fail_reason']="Reason: %s.";
 	$plugin_tx['hi_updatecheck']['message_up-to-date']="is up to date.";
 	$plugin_tx['hi_updatecheck']['message_update-available']="For %s is the new version %s available!";
 	$plugin_tx['hi_updatecheck']['message_update-critical']="This is a critical update! Please install the new version as soon as possible!";

--- a/languages/en.php
+++ b/languages/en.php
@@ -8,6 +8,7 @@
 	$plugin_tx['hi_updatecheck']['message_searching']="Searching updates for";
 	$plugin_tx['hi_updatecheck']['message_download']="Visit downloadpage »";
 	$plugin_tx['hi_updatecheck']['message_fail']="Updatecheck for %s failed!";
+	$plugin_tx['hi_updatecheck']['message_fail_reason']="Reason: %s.";
 	$plugin_tx['hi_updatecheck']['message_up-to-date']="is up to date.";
 	$plugin_tx['hi_updatecheck']['message_update-available']="For %s is the new version %s available!";
 	$plugin_tx['hi_updatecheck']['message_update-critical']="This is a critical update! Please install the new version as soon as possible!";


### PR DESCRIPTION
The update checks can fail for various reasons, so it appears to be
appropriate to report why they failed.  We therefore throw exceptions,
instead of returning NULL or FALSE from hi_fsFileGetContents() and
hi_versionInfo(), and report the exception messages as failure reason.

Since update check failures are hopefully rare, we do not
internationalize the error messages, but rather hard-code them.  This
could still be improved, if necessary.

We neither report detailed errors for invalid local version.nfo, nor
for the quick update check.  The latter for obvious reasons, the former
might be improved later.

We throw general `RuntimeException`s for simplicity; this requires PHP
≥ 5.1.0, which doesn't appear to be an issue.