### PR TITLE
Fix case-sensitive parsing of Location headers

### DIFF
--- a/updatecheck.php
+++ b/updatecheck.php
@@ -425,7 +425,7 @@ function hi_fsFileGetContents($url, $timeout = 30) {
     } elseif ($status == 204 or $status == 304) { // No Content | Not modified
         return '';
     } elseif (in_array($status, Array(300, 301, 302, 303, 307))) {
-        preg_match('~Location: (?P<location>\S+)~', $header, $match);
+        preg_match('~Location: (?P<location>\S+)~i', $header, $match);
         $result = hi_fsFileGetContents($match['location'], $timeout);
     } elseif ($status >= 400) { // Any error
         return false;


### PR DESCRIPTION
HTTP headers are supposed to be case-insensitive, so `location:` is
perfectly valid; we need to cater to that.

See also <https://cmsimpleforum.com/viewtopic.php?t=17678&p=80666#p80667>.