### PR TITLE
Don't fail if installed version is newer

### DIFF
--- a/languages/de.php
+++ b/languages/de.php
@@ -11,6 +11,7 @@
     $plugin_tx['hi_updatecheck']['message_up-to-date']="ist aktuell.";
     $plugin_tx['hi_updatecheck']['message_update-available']="Für %s ist die neue Version %s verfügbar!";
     $plugin_tx['hi_updatecheck']['message_update-critical']="Dies ist ein kritisches Update! Bitte aktualisieren Sie Ihr System zeitnah!";
+	$plugin_tx['hi_updatecheck']['message_version-newer']="The installierte Version von %s ist neuer als %s! Ist es eine Vorab-Version?";
     $plugin_tx['hi_updatecheck']['message_no-versioninfo1']="Für %s sind keine Versions-Informationen vorhanden!";
     $plugin_tx['hi_updatecheck']['message_no-versioninfo2']="Kontaktieren Sie den Autor direkt, um Updates zu erhalten.";
     $plugin_tx['hi_updatecheck']['message_qc-update-found']="Es sind Updates verfügbar...";

--- a/languages/default.php
+++ b/languages/default.php
@@ -11,6 +11,7 @@
 	$plugin_tx['hi_updatecheck']['message_up-to-date']="is up to date.";
 	$plugin_tx['hi_updatecheck']['message_update-available']="For %s is the new version %s available!";
 	$plugin_tx['hi_updatecheck']['message_update-critical']="This is a critical update! Please install the new version as soon as possible!";
+	$plugin_tx['hi_updatecheck']['message_version-newer']="The installed version of %s is newer than %s! Is this a pre-release?";
 	$plugin_tx['hi_updatecheck']['message_no-versioninfo1']="For %s is no version-information available!";
 	$plugin_tx['hi_updatecheck']['message_no-versioninfo2']="Please contact the developer for more informations.";
 	$plugin_tx['hi_updatecheck']['message_qc-update-found']="Updates are available...";

--- a/languages/en.php
+++ b/languages/en.php
@@ -11,6 +11,7 @@
 	$plugin_tx['hi_updatecheck']['message_up-to-date']="is up to date.";
 	$plugin_tx['hi_updatecheck']['message_update-available']="For %s is the new version %s available!";
 	$plugin_tx['hi_updatecheck']['message_update-critical']="This is a critical update! Please install the new version as soon as possible!";
+	$plugin_tx['hi_updatecheck']['message_version-newer']="The installed version of %s is newer than %s! Is this a pre-release?";
 	$plugin_tx['hi_updatecheck']['message_no-versioninfo1']="For %s is no version-information available!";
 	$plugin_tx['hi_updatecheck']['message_no-versioninfo2']="Please contact the developer for more informations.";
 	$plugin_tx['hi_updatecheck']['message_qc-update-found']="Updates are available...";

--- a/updatecheck.php
+++ b/updatecheck.php
@@ -220,6 +220,10 @@ function hi_updateInfo($pluginname = '') {
             $msg .= '<p>' . $remoteVersion[4] . '</p>';
         }
         $msg .= '<p><a target="_blank" href="' . $remoteVersion[5] . '">' . $p_tx['message_download'] . '</a></p>';
+    } else {
+        // pre-release
+        $msg = '<b>' . sprintf($p_tx['message_version-newer'], $localVersion[0], $remoteVersion[2]) . '</b>';
+        $css_class = 'upd_info' . $css_suff;
     }
     //output
     return sprintf('<div class="%s">%s</div>', $css_class, $msg);


### PR DESCRIPTION
The installed version might be a pre-release, or perhaps the plugin
provider has not yet updated the server side version.nfo yet.  Instead
of failing the check, we warn the user about that (they should not use
pre-releases on pulic servers, but for testing this is fine).