### PR TITLE
Built in CMSimple_XH version.nfo should use HTTPS

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -36,7 +36,7 @@ define('UPD_VERSION', '1.4');
 define('UPD_DATE', '2016-01-10');
 
 //Path to core-Versioninfo
-define('CMSIMPLE_XH_VERSIONINFO', 'http://www.cmsimple-xh.org/userfiles/downloads/versioninfo/cmsimple_xh-version.nfo');
+define('CMSIMPLE_XH_VERSIONINFO', 'https://www.cmsimple-xh.org/userfiles/downloads/versioninfo/cmsimple_xh-version.nfo');
 
 include_once($pth['folder']['plugins'] . 'jquery/jquery.inc.php');
 include_jQuery();


### PR DESCRIPTION
https://github.com/TN03/hi_updatecheck/blob/d981bbb71c3dbff89b570632e9025dc1f0698468/version.nfo#L1

should also use HTTPS, but that might be more difficult to solve. :)